### PR TITLE
Error handling

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -69,7 +69,6 @@ jobs:
         config:
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: windows-latest, r: '3.6'}
           - {os: ubuntu-18.04,   r: 'release'}
 
     env:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Description: Implements the Long Long Term Memory Neural Network Cells ('LLTM').
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-SystemRequirements: C++11
+SystemRequirements: C++14
 RoxygenNote: 7.1.1
 LinkingTo: 
     Rcpp, torch

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,3 +9,7 @@ lltm_backward <- function(grad_h, grad_cell, new_cell, input_gate, output_gate, 
     .Call('_lltm_lltm_backward', PACKAGE = 'lltm', grad_h, grad_cell, new_cell, input_gate, output_gate, candidate_cell, X, gate_weights, weights)
 }
 
+lltm_raise_exception <- function() {
+    invisible(.Call('_lltm_lltm_raise_exception', PACKAGE = 'lltm'))
+}
+

--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${TORCH_CXX_FLAGS}")
 # If you want to separate your implementation in multiple files
 # add their paths after `src/lltm.cpp`, the spearator is a simple
 # space.
-set(LLTM_SRC src/lltm.cpp)
+set(LLTM_SRC src/lltm.cpp src/utils.cpp)
 
 # On Windows we use module definition files to declare what are
 # the exported functions from the library. It's similar to the

--- a/csrc/include/lltm/lltm.h
+++ b/csrc/include/lltm/lltm.h
@@ -8,6 +8,24 @@
 #define LLTM_API extern "C"
 #endif
 
+// https://github.com/mlverse/torch/blob/5468117a8d5d49d77aeb690e2a1121292cd97213/inst/include/utils.h#L11-L30
+template <typename F>
+class ScopeGuard {
+public:
+  explicit ScopeGuard(F&& f) noexcept : f_(std::forward<F>(f)) {}
+  ~ScopeGuard() noexcept { f_(); }
+private:
+  typename std::decay<F>::type f_;
+};
+
+template <typename F>
+ScopeGuard<F> makeScopeGuard(F&& f) {
+  return ScopeGuard<F>(std::forward<F>(f));
+}
+
+void host_exception_handler ();
+extern void* p_lltm_last_error;
+
 // Exceptions that happen inside functions from the C API must be handled back
 // in the host side (eg. in Rcpp) in so we can correctly return the exception
 // to R.
@@ -17,20 +35,25 @@
 // NULL if no exception ocurred or a string if an exception has been raised while
 // executing the C function.
 // Use this function by wrapping your C function into it.
-// This adds C++14 dependency.
+// This adds C++14 dependency. If the C++ dependency is really undesirable you
+// can be more verbose declare a function with the same signature that does what
+// what you want.
 auto handle_exceptions = [](const auto& f) {
   return [&](auto ... params) {
-    std::cout << "wrapper code" << std::endl;
+    auto sg = makeScopeGuard(host_exception_handler);
     return f(params...);
   };
 };
+
+LLTM_API void* lltm_last_error ();
+LLTM_API void lltm_last_error_clear();
 
 LLTM_API void* _c_lltm_forward (void* input, void* weights, void* bias, void* old_h,
                                 void* old_cell) noexcept;
 static auto c_lltm_forward = handle_exceptions(_c_lltm_forward);
 
 LLTM_API void* c_lltm_backward (void* grad_h, void* grad_cell, void* new_cell,
-                              void* input_gate, void* output_gate, void* candidate_cell,
-                              void* X, void* gate_weights, void* weights);
+                                void* input_gate, void* output_gate, void* candidate_cell,
+                                void* X, void* gate_weights, void* weights);
 
 

--- a/csrc/include/lltm/lltm.h
+++ b/csrc/include/lltm/lltm.h
@@ -8,21 +8,6 @@
 #define LLTM_API extern "C"
 #endif
 
-// https://github.com/mlverse/torch/blob/5468117a8d5d49d77aeb690e2a1121292cd97213/inst/include/utils.h#L11-L30
-template <typename F>
-class ScopeGuard {
-public:
-  explicit ScopeGuard(F&& f) noexcept : f_(std::forward<F>(f)) {}
-  ~ScopeGuard() noexcept { f_(); }
-private:
-  typename std::decay<F>::type f_;
-};
-
-template <typename F>
-ScopeGuard<F> makeScopeGuard(F&& f) {
-  return ScopeGuard<F>(std::forward<F>(f));
-}
-
 void host_exception_handler ();
 extern void* p_lltm_last_error;
 
@@ -36,12 +21,16 @@ extern void* p_lltm_last_error;
 // executing the C function.
 // Use this function by wrapping your C function into it.
 // This adds C++14 dependency. If the C++ dependency is really undesirable you
-// can be more verbose declare a function with the same signature that does what
-// what you want.
+// can be more verbose declaring a function with the same signature that calls
+// the C interface, and calls host_exception_handler() before returning. Note:
+// `host_exception_handler()` might raise exceptions so it's not a good idea to
+// call it in ScopeGuards or similar strategies.
+// Also this function only works if the wrapped function doesn't return void.
 auto handle_exceptions = [](const auto& f) {
   return [&](auto ... params) {
-    auto sg = makeScopeGuard(host_exception_handler);
-    return f(params...);
+    auto ret = f(params...);
+    host_exception_handler();
+    return ret;
   };
 };
 
@@ -55,5 +44,9 @@ static auto c_lltm_forward = handle_exceptions(_c_lltm_forward);
 LLTM_API void* c_lltm_backward (void* grad_h, void* grad_cell, void* new_cell,
                                 void* input_gate, void* output_gate, void* candidate_cell,
                                 void* X, void* gate_weights, void* weights);
+
+LLTM_API int _raise_exception ();
+static auto raise_exception = handle_exceptions(_raise_exception);
+
 
 

--- a/csrc/include/lltm/lltm.h
+++ b/csrc/include/lltm/lltm.h
@@ -8,10 +8,29 @@
 #define LLTM_API extern "C"
 #endif
 
-LLTM_API void* c_lltm_forward (void* input, void* weights, void* bias, void* old_h,
-                               void* old_cell);
-LLTM_API void* c_lltm_backward(void* grad_h, void* grad_cell, void* new_cell,
-                               void* input_gate, void* output_gate, void* candidate_cell,
-                               void* X, void* gate_weights, void* weights);
+// Exceptions that happen inside functions from the C API must be handled back
+// in the host side (eg. in Rcpp) in so we can correctly return the exception
+// to R.
+// This function returns a modified function that calls a host handler whenever
+// it's out of scope. Currently, the way we propose handling the exceptions is
+// to use the host_exception_handler() to check a global variable that is either
+// NULL if no exception ocurred or a string if an exception has been raised while
+// executing the C function.
+// Use this function by wrapping your C function into it.
+// This adds C++14 dependency.
+auto handle_exceptions = [](const auto& f) {
+  return [&](auto ... params) {
+    std::cout << "wrapper code" << std::endl;
+    return f(params...);
+  };
+};
+
+LLTM_API void* _c_lltm_forward (void* input, void* weights, void* bias, void* old_h,
+                                void* old_cell) noexcept;
+static auto c_lltm_forward = handle_exceptions(_c_lltm_forward);
+
+LLTM_API void* c_lltm_backward (void* grad_h, void* grad_cell, void* new_cell,
+                              void* input_gate, void* output_gate, void* candidate_cell,
+                              void* X, void* gate_weights, void* weights);
 
 

--- a/csrc/src/lltm.cpp
+++ b/csrc/src/lltm.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 #include "lltm/lltm.h"
 
-std::string *p_lltm_last_error = NULL;
 
 // https://stackoverflow.com/questions/40487123/how-to-wrap-calls-with-try-catch-block
 #define HANDLE_LLTM_EXCEPTION(...)                              \

--- a/csrc/src/lltm.cpp
+++ b/csrc/src/lltm.cpp
@@ -23,11 +23,11 @@
 
 #define HANDLE_EXCEPTION                                       \
 catch(const std::exception& ex) {                             \
-  p_lltm_last_error = new std::string(ex.what());             \
+  p_lltm_last_error = make_raw::string(ex.what());             \
 } catch (std::string& ex) {                                   \
-  p_lltm_last_error = new std::string(ex);                    \
+  p_lltm_last_error = make_raw::string(ex);                    \
 } catch (...) {                                               \
-  p_lltm_last_error = new std::string("Unknown error. ");     \
+  p_lltm_last_error = make_raw::string("Unknown error. ");     \
 }
 
 torch::Tensor d_sigmoid(torch::Tensor z) {
@@ -152,4 +152,12 @@ LLTM_API void* c_lltm_backward(
   );
 
   return make_raw::TensorList(result);
+}
+
+LLTM_API int _raise_exception ()
+{
+  try {
+    throw std::runtime_error("Error from LLTM");
+  } HANDLE_EXCEPTION
+  return 1;
 }

--- a/csrc/src/lltm.cpp
+++ b/csrc/src/lltm.cpp
@@ -5,6 +5,32 @@
 #include <vector>
 #include "lltm/lltm.h"
 
+std::string *p_lltm_last_error = NULL;
+
+// https://stackoverflow.com/questions/40487123/how-to-wrap-calls-with-try-catch-block
+#define HANDLE_LLTM_EXCEPTION(...)                              \
+[&]() -> decltype(auto) {                                       \
+  try {                                                         \
+    return __VA_ARGS__;                                         \
+  } catch(const std::exception& ex) {                           \
+    p_lltm_last_error = new std::string(ex.what());             \
+  } catch (std::string& ex) {                                   \
+    p_lltm_last_error = new std::string(ex);                    \
+  } catch (...) {                                               \
+    p_lltm_last_error = new std::string("Unknown error. ");     \
+  }                                                             \
+  return (void*)nullptr;                                        \
+}()                                                            \
+
+#define HANDLE_EXCEPTION                                       \
+catch(const std::exception& ex) {                             \
+  p_lltm_last_error = new std::string(ex.what());             \
+} catch (std::string& ex) {                                   \
+  p_lltm_last_error = new std::string(ex);                    \
+} catch (...) {                                               \
+  p_lltm_last_error = new std::string("Unknown error. ");     \
+}
+
 torch::Tensor d_sigmoid(torch::Tensor z) {
   auto s = torch::sigmoid(z);
   return (1 - s) * s;
@@ -86,19 +112,21 @@ std::vector<torch::Tensor> lltm_backward(
   return {d_old_h, d_input, d_weights, d_bias, d_old_cell};
 }
 
-LLTM_API void* c_lltm_forward (void* input,
-                               void* weights,
-                               void* bias,
-                               void* old_h,
-                               void* old_cell) {
-  auto result = lltm_forward(
-    from_raw::Tensor(input),
-    from_raw::Tensor(weights),
-    from_raw::Tensor(bias),
-    from_raw::Tensor(old_h),
-    from_raw::Tensor(old_cell)
-  );
-  return make_raw::TensorList(result);
+void* _c_lltm_forward (void* input,
+                       void* weights,
+                       void* bias,
+                       void* old_h,
+                       void* old_cell) noexcept {
+  try {
+    return make_raw::TensorList(lltm_forward(
+        from_raw::Tensor(input),
+        from_raw::Tensor(weights),
+        from_raw::Tensor(bias),
+        from_raw::Tensor(old_h),
+        from_raw::Tensor(old_cell)
+    ));
+  } HANDLE_EXCEPTION
+  return (void*) nullptr;
 }
 
 LLTM_API void* c_lltm_backward(

--- a/csrc/src/lltm.def
+++ b/csrc/src/lltm.def
@@ -1,4 +1,6 @@
 LIBRARY LLTM
 EXPORTS
-  c_lltm_forward
+  lltm_last_error
+  lltm_last_error_clear
+  _c_lltm_forward
   c_lltm_backward

--- a/csrc/src/lltm.def
+++ b/csrc/src/lltm.def
@@ -4,3 +4,4 @@ EXPORTS
   lltm_last_error_clear
   _c_lltm_forward
   c_lltm_backward
+  _raise_exception

--- a/csrc/src/utils.cpp
+++ b/csrc/src/utils.cpp
@@ -1,0 +1,17 @@
+#include <lantern/types.h>
+#include <iostream>
+#include <vector>
+#include "lltm/lltm.h"
+
+void * p_lltm_last_error = NULL;
+
+LLTM_API void* lltm_last_error()
+{
+  return p_lltm_last_error;
+}
+
+LLTM_API void lltm_last_error_clear()
+{
+  p_lltm_last_error = NULL;
+}
+

--- a/inst/def/lltm.def
+++ b/inst/def/lltm.def
@@ -1,4 +1,6 @@
 LIBRARY LLTM
 EXPORTS
-  c_lltm_forward
+  lltm_last_error
+  lltm_last_error_clear
+  _c_lltm_forward
   c_lltm_backward

--- a/inst/def/lltm.def
+++ b/inst/def/lltm.def
@@ -4,3 +4,4 @@ EXPORTS
   lltm_last_error_clear
   _c_lltm_forward
   c_lltm_backward
+  _raise_exception

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -17,3 +17,4 @@ lltm: clean
 clean:
 	rm -rf lltm.lib
 
+CXX_STD = CXX14

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -45,10 +45,20 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// lltm_raise_exception
+void lltm_raise_exception();
+RcppExport SEXP _lltm_lltm_raise_exception() {
+BEGIN_RCPP
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    lltm_raise_exception();
+    return R_NilValue;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_lltm_lltm_forward", (DL_FUNC) &_lltm_lltm_forward, 5},
     {"_lltm_lltm_backward", (DL_FUNC) &_lltm_lltm_backward, 9},
+    {"_lltm_lltm_raise_exception", (DL_FUNC) &_lltm_lltm_raise_exception, 0},
     {NULL, NULL, 0}
 };
 

--- a/src/code.cpp
+++ b/src/code.cpp
@@ -48,3 +48,9 @@ torch::TensorList lltm_backward (
     weights.get()
   );
 }
+
+// [[Rcpp::export]]
+void lltm_raise_exception ()
+{
+  raise_exception();
+}

--- a/src/lltm/lltm.h
+++ b/src/lltm/lltm.h
@@ -8,6 +8,24 @@
 #define LLTM_API extern "C"
 #endif
 
+// https://github.com/mlverse/torch/blob/5468117a8d5d49d77aeb690e2a1121292cd97213/inst/include/utils.h#L11-L30
+template <typename F>
+class ScopeGuard {
+public:
+  explicit ScopeGuard(F&& f) noexcept : f_(std::forward<F>(f)) {}
+  ~ScopeGuard() noexcept { f_(); }
+private:
+  typename std::decay<F>::type f_;
+};
+
+template <typename F>
+ScopeGuard<F> makeScopeGuard(F&& f) {
+  return ScopeGuard<F>(std::forward<F>(f));
+}
+
+void host_exception_handler ();
+extern void* p_lltm_last_error;
+
 // Exceptions that happen inside functions from the C API must be handled back
 // in the host side (eg. in Rcpp) in so we can correctly return the exception
 // to R.
@@ -17,20 +35,25 @@
 // NULL if no exception ocurred or a string if an exception has been raised while
 // executing the C function.
 // Use this function by wrapping your C function into it.
-// This adds C++14 dependency.
+// This adds C++14 dependency. If the C++ dependency is really undesirable you
+// can be more verbose declare a function with the same signature that does what
+// what you want.
 auto handle_exceptions = [](const auto& f) {
   return [&](auto ... params) {
-    std::cout << "wrapper code" << std::endl;
+    auto sg = makeScopeGuard(host_exception_handler);
     return f(params...);
   };
 };
+
+LLTM_API void* lltm_last_error ();
+LLTM_API void lltm_last_error_clear();
 
 LLTM_API void* _c_lltm_forward (void* input, void* weights, void* bias, void* old_h,
                                 void* old_cell) noexcept;
 static auto c_lltm_forward = handle_exceptions(_c_lltm_forward);
 
 LLTM_API void* c_lltm_backward (void* grad_h, void* grad_cell, void* new_cell,
-                              void* input_gate, void* output_gate, void* candidate_cell,
-                              void* X, void* gate_weights, void* weights);
+                                void* input_gate, void* output_gate, void* candidate_cell,
+                                void* X, void* gate_weights, void* weights);
 
 

--- a/src/lltm/lltm.h
+++ b/src/lltm/lltm.h
@@ -8,21 +8,6 @@
 #define LLTM_API extern "C"
 #endif
 
-// https://github.com/mlverse/torch/blob/5468117a8d5d49d77aeb690e2a1121292cd97213/inst/include/utils.h#L11-L30
-template <typename F>
-class ScopeGuard {
-public:
-  explicit ScopeGuard(F&& f) noexcept : f_(std::forward<F>(f)) {}
-  ~ScopeGuard() noexcept { f_(); }
-private:
-  typename std::decay<F>::type f_;
-};
-
-template <typename F>
-ScopeGuard<F> makeScopeGuard(F&& f) {
-  return ScopeGuard<F>(std::forward<F>(f));
-}
-
 void host_exception_handler ();
 extern void* p_lltm_last_error;
 
@@ -36,12 +21,16 @@ extern void* p_lltm_last_error;
 // executing the C function.
 // Use this function by wrapping your C function into it.
 // This adds C++14 dependency. If the C++ dependency is really undesirable you
-// can be more verbose declare a function with the same signature that does what
-// what you want.
+// can be more verbose declaring a function with the same signature that calls
+// the C interface, and calls host_exception_handler() before returning. Note:
+// `host_exception_handler()` might raise exceptions so it's not a good idea to
+// call it in ScopeGuards or similar strategies.
+// Also this function only works if the wrapped function doesn't return void.
 auto handle_exceptions = [](const auto& f) {
   return [&](auto ... params) {
-    auto sg = makeScopeGuard(host_exception_handler);
-    return f(params...);
+    auto ret = f(params...);
+    host_exception_handler();
+    return ret;
   };
 };
 
@@ -55,5 +44,9 @@ static auto c_lltm_forward = handle_exceptions(_c_lltm_forward);
 LLTM_API void* c_lltm_backward (void* grad_h, void* grad_cell, void* new_cell,
                                 void* input_gate, void* output_gate, void* candidate_cell,
                                 void* X, void* gate_weights, void* weights);
+
+LLTM_API int _raise_exception ();
+static auto raise_exception = handle_exceptions(_raise_exception);
+
 
 

--- a/src/lltm/lltm.h
+++ b/src/lltm/lltm.h
@@ -8,10 +8,29 @@
 #define LLTM_API extern "C"
 #endif
 
-LLTM_API void* c_lltm_forward (void* input, void* weights, void* bias, void* old_h,
-                               void* old_cell);
-LLTM_API void* c_lltm_backward(void* grad_h, void* grad_cell, void* new_cell,
-                               void* input_gate, void* output_gate, void* candidate_cell,
-                               void* X, void* gate_weights, void* weights);
+// Exceptions that happen inside functions from the C API must be handled back
+// in the host side (eg. in Rcpp) in so we can correctly return the exception
+// to R.
+// This function returns a modified function that calls a host handler whenever
+// it's out of scope. Currently, the way we propose handling the exceptions is
+// to use the host_exception_handler() to check a global variable that is either
+// NULL if no exception ocurred or a string if an exception has been raised while
+// executing the C function.
+// Use this function by wrapping your C function into it.
+// This adds C++14 dependency.
+auto handle_exceptions = [](const auto& f) {
+  return [&](auto ... params) {
+    std::cout << "wrapper code" << std::endl;
+    return f(params...);
+  };
+};
+
+LLTM_API void* _c_lltm_forward (void* input, void* weights, void* bias, void* old_h,
+                                void* old_cell) noexcept;
+static auto c_lltm_forward = handle_exceptions(_c_lltm_forward);
+
+LLTM_API void* c_lltm_backward (void* grad_h, void* grad_cell, void* new_cell,
+                              void* input_gate, void* output_gate, void* candidate_cell,
+                              void* X, void* gate_weights, void* weights);
 
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,14 @@
+#include <Rcpp.h>
+#include <iostream>
+#define LLTM_HEADERS_ONLY
+#include "lltm/lltm.h"
+#include <torch.h>
+
+void host_exception_handler ()
+{
+  if (lltm_last_error())
+  {
+    lltm_last_error_clear();
+    Rcpp::stop(Rcpp::as<std::string>(torch::string(lltm_last_error())));
+  }
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -8,7 +8,8 @@ void host_exception_handler ()
 {
   if (lltm_last_error())
   {
+    auto msg = Rcpp::as<std::string>(torch::string(lltm_last_error()));
     lltm_last_error_clear();
-    Rcpp::stop(Rcpp::as<std::string>(torch::string(lltm_last_error())));
+    Rcpp::stop(msg);
   }
 }

--- a/tests/testthat/test-lltm.R
+++ b/tests/testthat/test-lltm.R
@@ -18,3 +18,9 @@ test_that("multiplication works", {
   expect_equal(rnn$weights$grad$shape, c(384, 160))
   expect_equal(rnn$bias$grad$shape, c(384))
 })
+
+test_that("raise exceptions", {
+
+  expect_error(lltm_raise_exception(), "Error from LLTM")
+
+})


### PR DESCRIPTION
Handle exceptions raised from C++ in the `csrc` directory. 
Exceptions are not safe if raised from code compiled in MSVC that interface with Rcpp et al compiled with MinGW. Thus we need to handle them to make sure no function in the C api raises C++ exceptions.

Instead we catch the exceptions and save them into a pointer that can then be checked from Rcpp and we re-raise the exception if needed.